### PR TITLE
Crafting UI fix when filter in batch mode (#18842)

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -557,7 +557,7 @@ const recipe *select_crafting_recipe( int &batch_size )
             }
             batch = !batch;
             if( batch ) {
-                batch_line = line;
+                batch_line = (batch_line >= (int)current.size() ? 0 : line);
                 chosen = current[batch_line];
             } else {
                 line = batch_line;


### PR DESCRIPTION
The problem was caused from how 'current' contains only the currently
listed items, and when batch is initially incurred in game, batch_line
is set to the currently highlighted line, however, should 'current'
contain less items than the value of  'batch_line', which is set equal
to 'line', then a memory access violation occurs. This was fixed by
checking if the batch_line value was greater than the total size of
'current' and setting batch_line equal to 0 if it returned true